### PR TITLE
Fix : 견적서 작성완료 후 toast 안뜨는 오류 수정

### DIFF
--- a/src/pages/UserEstimationPage.tsx
+++ b/src/pages/UserEstimationPage.tsx
@@ -95,8 +95,8 @@ const UEPage = () => {
       // API 호출 실행
       const response = await apiCall();
 
-      // 상태 코드가 200인 경우
-      if (response.status === 200) {
+      // 상태 코드가 201인 경우
+      if (response.status === 201 || response.status === 200) {
         addToasts({
           type: 'success',
           title: successMsg,


### PR DESCRIPTION
## #️⃣ Issue Number
#299 

## 📝 요약(Summary)

### UserEstimationPage.tsx
- 견적요청 성공시 toast 메세지 안뜨고 페이지 이동 안하는 오류
   -> 서버에서 성공 status를 200으로 내려줬었는데 저녁에는 201로 바뀌어져 있음
   -> if (response.status === 201 || response.status === 200) 로 바꿈

#299 

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
